### PR TITLE
Centralize manifest utilities and apply manifest hooks in parsing/cleaning

### DIFF
--- a/src/imperandi/ingest/clean.py
+++ b/src/imperandi/ingest/clean.py
@@ -1,7 +1,6 @@
 import argparse
 import hashlib
 import importlib
-import json
 from ast import literal_eval
 from pathlib import Path
 
@@ -16,6 +15,7 @@ from imperandi.ingest.config import (
     DEFAULT_VOLUME_LOWERBOUND,
     DEFAULT_VOLUME_UPPERBOUND,
 )
+from imperandi.utils.manifest import load_manifest, resolve_hook
 from imperandi.utils.geometry import (
     as_float_array,
     classify_plane_from_iop,
@@ -72,41 +72,13 @@ def parse_arguments():
     return args
 
 
-def load_manifest(manifest_arg: str | None) -> dict:
-    if not manifest_arg:
-        return {}
-
-    manifest_path = Path(manifest_arg)
-    if not manifest_path.suffix:
-        manifest_path = (
-            Path(__file__).resolve().parents[1]
-            / "datasets_config"
-            / "manifests"
-            / f"{manifest_arg}.json"
-        )
-    elif not manifest_path.is_file():
-        manifest_path = (
-            Path(__file__).resolve().parents[1]
-            / "datasets_config"
-            / "manifests"
-            / manifest_arg
-        )
-
-    if not manifest_path.exists():
-        raise FileNotFoundError(f"Manifest not found: {manifest_arg}")
-
-    with manifest_path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
-def resolve_hook(manifest: dict, hook_key: str):
+def resolve_standardization_hook(manifest: dict, hook_key: str):
     hook_config = manifest.get("id_standardization", {})
-    module_name = hook_config.get("hook_module")
-    function_name = hook_config.get(hook_key)
-    if not module_name or not function_name:
-        return None
-    module = importlib.import_module(f"imperandi.{module_name}")
-    return getattr(module, function_name)
+    normalized_config = {
+        "hook_module": hook_config.get("hook_module"),
+        "function": hook_config.get(hook_key),
+    }
+    return resolve_hook(normalized_config)
 
 
 def resolve_hook_module(manifest: dict):
@@ -186,7 +158,7 @@ def report_change(df, previous_df, col=None):
 
 
 def standardize_patient_keys(df, manifest: dict):
-    hook = resolve_hook(manifest, "patient_key")
+    hook = resolve_standardization_hook(manifest, "patient_key")
     if not hook:
         return df
     df["patient_key"] = df["patient_key"].apply(hook)
@@ -715,7 +687,7 @@ def clean_and_save_data(csv_path, csv_path_out, csv_dict_path, manifest, volume_
 
 if __name__ == "__main__":
     args = parse_arguments()
-    manifest = load_manifest(args.manifest)
+    manifest = load_manifest(args.manifest, base_path=Path(__file__).resolve().parents[1])
     clean_and_save_data(
         args.csv_path,
         args.csv_path_out,

--- a/src/imperandi/ingest/parse.py
+++ b/src/imperandi/ingest/parse.py
@@ -32,6 +32,12 @@ def parse_arguments():
         required=True,
         help="Directory to save output CSV files.",
     )
+    parser.add_argument(
+        "--manifest",
+        type=str,
+        default=None,
+        help="Dataset manifest name or path to manifest JSON.",
+    )
 
     # Tag reading
     parser.add_argument(
@@ -103,6 +109,45 @@ def parse_arguments():
     args = parser.parse_args()
     print(f"Running {Path(__file__).name} with args: {args}")
     return args
+
+
+from imperandi.utils.manifest import load_manifest, resolve_hook
+
+
+def apply_id_standardization(df: pd.DataFrame, manifest: dict) -> pd.DataFrame:
+    hook_config = manifest.get("id_standardization", {})
+    hook = resolve_hook(hook_config)
+    if not hook or "patient_key" not in df.columns:
+        return df
+    df["patient_key"] = df["patient_key"].apply(hook)
+    return df
+
+
+def apply_derived_columns(df: pd.DataFrame, manifest: dict) -> pd.DataFrame:
+    derived_columns = manifest.get("derived_columns", [])
+    if not derived_columns:
+        return df
+
+    for derived in derived_columns:
+        from_column = derived.get("from_column")
+        if not from_column or from_column not in df.columns:
+            continue
+        hook = resolve_hook(derived)
+        if not hook:
+            continue
+        derived_values = df[from_column].apply(hook)
+        derived_df = derived_values.apply(pd.Series)
+        if derived_df.empty:
+            continue
+        join_mode = derived.get("join_mode", "missing_only")
+        if join_mode == "overwrite":
+            df = df.drop(columns=[col for col in derived_df.columns if col in df.columns])
+            df = df.join(derived_df)
+        else:
+            derived_df = derived_df.loc[:, ~derived_df.columns.isin(df.columns)]
+            if not derived_df.empty:
+                df = df.join(derived_df)
+    return df
 
 
 # -------------------------
@@ -294,6 +339,7 @@ def main(args):
     output_dir = Path(args.output_dir)
     ensure_directory_exists(output_dir)
     print(f"Output directory: {output_dir}")
+    manifest = load_manifest(args.manifest, base_path=Path(__file__).resolve().parents[1])
 
     dicom_paths = get_dicom_paths(root_path)
     print(f"Found {len(dicom_paths)} DICOM files under {root_path}")
@@ -335,6 +381,8 @@ def main(args):
         study_tag=args.study_id_from,
         series_tag=args.series_id_from,
     )
+    df = apply_id_standardization(df, manifest)
+    df = apply_derived_columns(df, manifest)
 
     # 4) output final df
     out_final = output_dir / "dicom_index.csv"

--- a/src/imperandi/utils/manifest.py
+++ b/src/imperandi/utils/manifest.py
@@ -1,0 +1,29 @@
+import importlib
+import json
+from pathlib import Path
+
+
+def load_manifest(manifest_arg: str | None, *, base_path: Path) -> dict:
+    if not manifest_arg:
+        return {}
+
+    manifest_path = Path(manifest_arg)
+    if not manifest_path.suffix:
+        manifest_path = base_path / "datasets_config" / "manifests" / f"{manifest_arg}.json"
+    elif not manifest_path.is_file():
+        manifest_path = base_path / "datasets_config" / "manifests" / manifest_arg
+
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Manifest not found: {manifest_arg}")
+
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def resolve_hook(hook_config: dict):
+    module_name = hook_config.get("hook_module")
+    function_name = hook_config.get("function")
+    if not module_name or not function_name:
+        return None
+    module = importlib.import_module(f"imperandi.{module_name}")
+    return getattr(module, function_name)


### PR DESCRIPTION
### Motivation
- Consolidate manifest loading and hook resolution so parsing and cleaning share the same behavior for dataset manifests. 
- Ensure dataset-specific ID standardization and derived column generation are applied consistently during DICOM parsing and cleaning. 
- Replace duplicated manifest logic with a single reusable utility to simplify maintenance and avoid subtle inconsistencies.

### Description
- Add `src/imperandi/utils/manifest.py` with `load_manifest(manifest_arg, *, base_path)` and `resolve_hook(hook_config)` to centralize manifest JSON loading and hook function resolution. 
- Update `src/imperandi/ingest/parse.py` to accept `--manifest`, load the manifest with `load_manifest(..., base_path=...)`, and add `apply_id_standardization` and `apply_derived_columns` helpers which are invoked after `choose_ids` so IDs and derived columns are present before writing `dicom_index.csv`. 
- Update `src/imperandi/ingest/clean.py` to reuse `load_manifest` and `resolve_hook` by introducing `resolve_standardization_hook` that normalizes the old `id_standardization` config to the shared `resolve_hook` shape, and replace the duplicated manifest-loading code with the shared helper. 
- Minor import reorganization and cleanup to remove duplicate `importlib`/`json` implementations and reduce code duplication.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981cc4feb84832ebde84a20f018e2db)