### PR TITLE
Add Sphinx documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/source/conf.py
+  fail_on_warning: false
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+To generate the documentation locally, do the following:
+
+- Make sur you installed the requirement at the root of this repo
+    ```
+    pip install -r ../requirements.txt
+    ```
+
+- Install [sphinx](https://www.sphinx-doc.org/en/master/usage/quickstart.html) with pip and dependencies
+
+    ```
+    pip install sphinx
+    pip install sphinx_rtd_theme
+    pip install sphinxcontrib.bibtex
+    ```
+
+- Then build the documentation:
+
+    ```
+    sphinx-build -b html source build
+    ```
+
+**note** do not pay attention the logs warnings
+
+Then go to `build` folder and open the `intex.html` file (in a browser for example)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx>=7,<9
+sphinx-rtd-theme>=2,<4
+myst-parser>=2,<5
+

--- a/docs/source/api/extract.rst
+++ b/docs/source/api/extract.rst
@@ -1,0 +1,17 @@
+Extraction API
+==============
+
+Contrast phase
+--------------
+
+.. automodule:: imperandi.extract.phase
+   :members:
+   :undoc-members:
+
+Radiomics
+----------
+
+.. automodule:: imperandi.extract.radiomics
+   :members:
+   :undoc-members:
+

--- a/docs/source/api/imperandi.rst
+++ b/docs/source/api/imperandi.rst
@@ -1,0 +1,14 @@
+Top-level package
+=================
+
+.. automodule:: imperandi
+   :members:
+   :undoc-members:
+
+Command-line dispatcher
+-----------------------
+
+.. automodule:: imperandi.cli
+   :members:
+   :undoc-members:
+

--- a/docs/source/api/ingest.rst
+++ b/docs/source/api/ingest.rst
@@ -1,0 +1,24 @@
+Ingest API
+==========
+
+Parsing
+-------
+
+.. automodule:: imperandi.ingest.parse
+   :members:
+   :undoc-members:
+
+Cleaning
+--------
+
+.. automodule:: imperandi.ingest.clean
+   :members:
+   :undoc-members:
+
+Manifest hooks
+--------------
+
+.. automodule:: imperandi.ingest.apply_hook_manifests
+   :members:
+   :undoc-members:
+

--- a/docs/source/api/process.rst
+++ b/docs/source/api/process.rst
@@ -1,0 +1,17 @@
+Processing API
+==============
+
+DICOM conversion
+----------------
+
+.. automodule:: imperandi.process.convert
+   :members:
+   :undoc-members:
+
+Segmentation
+------------
+
+.. automodule:: imperandi.process.segment
+   :members:
+   :undoc-members:
+

--- a/docs/source/api/qc.rst
+++ b/docs/source/api/qc.rst
@@ -1,0 +1,24 @@
+Quality-control Dashboards
+===================
+
+Interactive viewer in Jupyter Notebook
+---------------
+
+.. figure:: https://raw.githubusercontent.com/dmandache/IMPERANDI/main/static/viewer-demo.png
+   :alt: Viewer interface example
+   :width: 700px
+   :align: center
+
+   Example of the IMPERANDI interactive viewer interface in a Jupyter Notebook.
+
+.. automodule:: imperandi.qc.viewer
+   :members:
+   :undoc-members:
+
+Viewer resampling helpers
+------------------
+
+.. automodule:: imperandi.qc.viewer_resample
+   :members:
+   :undoc-members:
+

--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -1,0 +1,118 @@
+# Command-line reference
+
+The installed entry point is `imperandi`; `python -m imperandi` is equivalent.
+
+```bash
+imperandi [--log-level LEVEL] [--log-file PATH] [--quiet] COMMAND [OPTIONS]
+```
+
+Global options must appear before the subcommand. `--log-level` accepts normal
+Python logging levels such as `DEBUG`, `INFO`, and `WARNING`.
+
+Run `imperandi COMMAND --help` for the authoritative option list in your
+installed version.
+
+## `parse`
+
+```bash
+imperandi parse [ROOT_PATH] [OUTPUT_DIR] [OPTIONS]
+```
+
+Reads selected DICOM headers and writes `dicom_index.csv`. Important options:
+
+- `--root_path`, `--output_dir`: named alternatives to positional paths; named
+  values win when both forms are supplied.
+- `--manifest NAME_OR_JSON`: dataset configuration.
+- `--id_source {auto,tags,path}` and `--patient_key_from`, `--study_id_from`,
+  `--series_id_from`: ID derivation.
+- `--tags A,B,C`: additional DICOM keywords.
+- `--force_dicom_read`: tolerate non-conformant DICOM files.
+- `--snapshot_tags`, `--snapshot_sample_size`, `--snapshot_seed`: recursive tag
+  snapshot controls.
+- `--num_workers`: header-reading process count.
+- `--archive_max_depth`, `--archive_cache_dir`, `--keep_archive_cache`: archive
+  controls.
+
+## `clean`
+
+```bash
+imperandi clean [CSV_PATH] [CSV_PATH_OUT] [OPTIONS]
+```
+
+Curates parsed instance metadata into a volume-level table. `--csv_path`
+accepts one or more CSVs. Use `--volume-length-min-mm` and
+`--volume-length-max-mm` to change reconstructed-length bounds.
+
+## `ingest`
+
+```bash
+imperandi ingest [ROOT_PATH] [OUTPUT_DIR] [OPTIONS]
+```
+
+Combines `parse` and `clean`. It accepts parse/archive options plus clean's
+length bounds and `--csv_dict_path`. `--csv_path_out` selects the final cleaned
+table; it defaults to `<output_dir>/dicom_index_clean.csv`.
+
+## `convert`
+
+```bash
+imperandi convert [CSV_PATH] [OUTPUT_DIR] [OPTIONS]
+```
+
+Converts series listed in one or more CSV files. The default final table is
+`nifti_index.csv` and the default failure table is `conv_errors.csv`, both next
+to the input CSV. Use `--num_workers` to control conversion parallelism.
+
+## `segment`
+
+```bash
+imperandi segment [CSV_PATH] [CSV_PATH_OUT] [OPTIONS]
+```
+
+Requires `imperandi[segment]`. It reads `nifti_path` and runs the selected
+manifest's `segmentation` configuration.
+
+- `--manifest NAME_OR_JSON`: task and post-processing configuration.
+- `--num_workers`: process count.
+- `--start_method {spawn,fork,forkserver}`: multiprocessing strategy; `spawn`
+  is the robust default.
+- `--timeout_sec`: per-volume timeout.
+- `--force`: rerun when output masks already exist.
+- `--error_csv_path`: defaults to `seg_errors.csv` beside the input.
+
+The output table overwrites the input unless `--csv_path_out` is supplied.
+
+## `phase`
+
+```bash
+imperandi phase [CSV_PATH] [CSV_PATH_OUT] [OPTIONS]
+```
+
+Requires `imperandi[segment]` and an input `nifti_path` column. It updates the
+input table by default. Existing populated `totalseg_phase` values are skipped;
+`--force` recomputes them. Failures default to `phase_errors.csv`.
+
+## `radiomics`
+
+```bash
+imperandi radiomics [CSV_PATH] [CSV_PATH_OUT] [OPTIONS]
+```
+
+Requires `imperandi[radiomics]`, `nifti_path`, and `mask_*` columns.
+
+- `--manifest NAME_OR_JSON`: load settings and filters from `radiomics`.
+- `--pyradiomics_settings PARAMS.yaml`: use explicit PyRadiomics settings.
+- `--filter column=value1,value2`: filter rows; repeat for more columns.
+- `--skip_filter`: ignore both CLI and manifest filters.
+- `--error_csv_path`: defaults to `radiomics_errors.csv`.
+
+When a manifest contains PyRadiomics settings, they take precedence over an
+explicit YAML path and a warning is emitted.
+
+## Shared long-running options
+
+`parse`, `convert`, `segment`, `phase`, and `radiomics` accept checkpoint and
+resume options described in [Workflow](workflow.md). All commands support
+`--dry-run`; `clean` and `ingest` do not themselves expose resume state beyond
+the parse portion used by ingest.
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,66 @@
+"""Sphinx configuration for the IMPERANDI documentation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+
+project = "IMPERANDI"
+author = "Diana Mandache"
+copyright = "2026, Diana Mandache"
+
+try:
+    from imperandi import __version__
+except ImportError:
+    __version__ = "0.0.0"
+
+version = release = __version__
+
+extensions = [
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+]
+
+source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
+myst_enable_extensions = ["colon_fence", "deflist", "fieldlist"]
+
+autodoc_default_options = {
+    "members": True,
+    "show-inheritance": True,
+}
+autodoc_typehints = "description"
+autoclass_content = "both"
+
+# Keep API docs buildable with the base installation. These packages are only
+# needed by segmentation, radiomics, or the notebook viewers.
+autodoc_mock_imports = [
+    "IPython",
+    "SimpleITK",
+    "TotalSegmentator",
+    "ipywidgets",
+    "matplotlib",
+    "param",
+    "panel",
+    "pyradiomics",
+    "radiomics",
+    "skimage",
+    "torch",
+    "torchio",
+    "xgboost",
+]
+
+templates_path = []
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+html_theme = "sphinx_rtd_theme"
+html_title = "IMPERANDI documentation"
+html_theme_options = {
+    "collapse_navigation": False,
+    "navigation_depth": 3,
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,58 @@
+IMPERANDI
+=========
+
+.. figure:: https://raw.githubusercontent.com/dmandache/IMPERANDI/main/static/imperandi-logo.png
+   :alt: Viewer interface example
+   :width: 700px
+   :align: center
+
+IMaging PREprocessing And Normalization for Diagnostic
+Interoperability is a Python framework and command-line interface for
+turning heterogeneous CT DICOM exports into traceable, analysis-ready cohorts.
+
+IMPERANDI discovers DICOM data, curates metadata,
+converts volumes to NIfTI, runs configurable segmentation and contrast-phase
+analysis, extracts radiomics, and supports interactive quality control.
+
+.. note::
+
+   IMPERANDI is research software. It is not a certified medical device and
+   its outputs require appropriate validation before clinical use.
+
+Start here
+----------
+
+* :doc:`installation` — install the base package and optional feature sets.
+* :doc:`quickstart` — run a first end-to-end cohort.
+* :doc:`workflow` — understand stage boundaries, resuming, and data flow.
+* :doc:`cli` — find command and option details.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User guide
+
+   installation
+   quickstart
+   workflow
+   cli
+   outputs
+   manifests
+   troubleshooting
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Python API
+
+   api/imperandi
+   api/ingest
+   api/process
+   api/extract
+   api/qc
+
+Indices and tables
+------------------
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -1,0 +1,68 @@
+# Installation
+
+IMPERANDI requires Python 3.10 or newer. A virtual environment keeps its
+scientific dependencies isolated from other projects.
+
+```bash
+git clone https://github.com/dmandache/IMPERANDI.git
+cd IMPERANDI
+python3 -m venv .venv
+source .venv/bin/activate        # Windows PowerShell: .venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -e .
+```
+
+Confirm that the command is available:
+
+```bash
+imperandi --help
+```
+
+## Optional features
+
+The base installation supports DICOM ingest and NIfTI conversion. Install only
+the heavier feature sets needed by your workflow:
+
+```bash
+# TotalSegmentator-based segmentation and phase extraction
+python -m pip install -e ".[segment]"
+
+# PyRadiomics extraction
+python -m pip install -e ".[radiomics]"
+
+# Tests, linting, and Jupyter tools
+python -m pip install -e ".[dev]"
+
+# Every optional feature
+python -m pip install -e ".[all]"
+```
+
+TotalSegmentator may download model weights the first time a segmentation task
+runs. Plan for network access and sufficient local storage at installation or
+model-prefetch time; cohort processing can then run in a controlled environment.
+
+## Build these docs
+
+Install the project and documentation dependencies, then invoke Sphinx from the
+repository root:
+
+```bash
+python -m pip install -e .
+python -m pip install -r docs/requirements.txt
+sphinx-build -W --keep-going -b html docs/source docs/build/html
+```
+
+Open `docs/build/html/index.html` in a browser. Omitting `-W` is useful while
+editing, but CI should treat documentation warnings as errors.
+
+## Jupyter quality-control viewer
+
+The classic viewer uses the widget backend. After installing the development
+dependencies, an optional named kernel can be registered with:
+
+```bash
+python -m ipykernel install --user \
+  --name imperandi \
+  --display-name "IMPERANDI"
+```
+

--- a/docs/source/manifests.md
+++ b/docs/source/manifests.md
@@ -1,0 +1,90 @@
+# Manifests
+
+A manifest is a JSON document that captures dataset-specific identity rules,
+hooks, segmentation tasks, post-processing, and radiomics configuration. Pass a
+built-in name (`generic` or `operandi`) or a path to a JSON file:
+
+```bash
+imperandi ingest --root_path ./dicom --manifest generic
+imperandi segment ./nifti_index.csv --manifest ./site-a.json
+```
+
+Built-ins live under `src/imperandi/datasets_config/manifests/`. Treat them as
+examples; keep institution-specific configuration in a reviewed, versioned
+file rather than editing package defaults in place.
+
+## Structure
+
+```json
+{
+  "dataset_name": "site-a",
+  "id_extraction": {
+    "source": "auto",
+    "force_dicom_read": false,
+    "patient_key": {"from_tag": "PatientID", "fallback": "path"},
+    "study_id": {"from_tag": "StudyInstanceUID", "fallback": "path"},
+    "series_id": {"from_tag": "SeriesInstanceUID", "fallback": "path"}
+  },
+  "id_standardization": {
+    "hook_module": "datasets_config.hooks.generic",
+    "function": "standardize_patient_key"
+  },
+  "segmentation": {
+    "backend": "totalsegmentator",
+    "tasks": [
+      {"task": "total", "extra": {"roi_subset": ["liver"]}},
+      {
+        "task": "liver_lesions",
+        "output": "liver_tumor",
+        "fetch_output": "liver_lesions"
+      }
+    ],
+    "postprocess": {
+      "merge_keys": ["liver", "liver_tumor"],
+      "output": "liver",
+      "radius_mm": 5.0,
+      "largest_cc": true,
+      "fill_holes": true,
+      "close": true
+    }
+  },
+  "radiomics": {
+    "pyradiomics": {
+      "setting": {"binWidth": 25},
+      "imageType": {"Original": {}}
+    },
+    "filters": {"totalseg_phase": ["portal_venous", "arterial_late"]}
+  }
+}
+```
+
+## Hooks
+
+`id_standardization` resolves a callable below the `imperandi` package and
+applies it to the raw patient key. A `derived_columns` list can similarly call
+functions that return mappings of extra fields. Each derived entry names a
+`from_column` and may set `join_mode` to `missing_only` (default) or
+`overwrite`.
+
+Custom hooks are executable Python, not passive configuration. Review them as
+code, test them against malformed and missing identifiers, and never load an
+untrusted manifest that points to untrusted modules.
+
+## Precedence
+
+Explicit parse CLI values override manifest-derived parse defaults. For
+radiomics, CLI `--filter` values take precedence per column, while manifest
+filters fill columns not specified on the CLI. `--skip_filter` disables all of
+them. Manifest PyRadiomics settings take precedence when both a manifest
+settings object and `--pyradiomics_settings` are supplied.
+
+## Validation advice
+
+Before a full run:
+
+1. run each command with `--dry-run`;
+2. parse a small representative sample;
+3. compare raw and standardized identifiers;
+4. verify expected mask column names;
+5. confirm radiomics filters retain the intended phases.
+

--- a/docs/source/outputs.md
+++ b/docs/source/outputs.md
@@ -1,0 +1,51 @@
+# Outputs
+
+CSV tables are the pipeline's audit spine. Each stage preserves existing
+columns and adds or normalizes the fields needed downstream.
+
+| Stage | Main output | Error/auxiliary output | Key additions |
+|---|---|---|---|
+| `parse` | `dicom_index.csv` | `dicom_index_errors.csv`; optional `dicom_tags_snapshot.ndjson` | IDs, `dicom_path`, selected DICOM tags |
+| `clean` | `<input>_clean.csv` | — | volume grouping, normalized date/time, ordering and geometry fields |
+| `ingest` | `dicom_index_clean.csv` | parse artifacts | parsed and curated volume rows |
+| `convert` | `nifti_index.csv` | `conv_errors.csv` | `nifti_path` |
+| `segment` | input CSV in place, or `--csv_path_out` | `seg_errors.csv` and warning report when applicable | `mask_<output>` paths |
+| `phase` | input CSV in place, or `--csv_path_out` | `phase_errors.csv` | `totalseg_*`, including `totalseg_phase` |
+| `radiomics` | `<input>_radiomics.csv` | `radiomics_errors.csv` | ROI-prefixed PyRadiomics features |
+
+Defaults are relative to the input CSV or selected output directory. Explicit
+paths are recommended in scheduled pipelines.
+
+## Identity and traceability
+
+The core identifiers are `patient_key`, `study_id`, and `series_id`. Parse also
+retains `_patient_key_raw` when standardization is applied. `dicom_path` may
+serialize multiple files for a volume or contain archive-aware locations;
+consumers should not assume it is a single ordinary filesystem path.
+
+Long-running stages use an internal `_source_idx` for stable resume and merge
+behavior. It is removed from finalized user-facing tables.
+
+## Image and mask paths
+
+`nifti_path` identifies the converted CT image. Segmentation outputs are stored
+in columns beginning with `mask_`; their exact set follows the manifest tasks.
+Paths may be absolute depending on the supplied output directory, so moving a
+dataset can invalidate a table. If portability matters, move artifacts and
+rewrite paths as one controlled operation.
+
+## Error tables
+
+Error CSVs contain the failed source row plus an error message. A command can
+complete while some rows fail, making these tables part of the expected output
+rather than disposable logs. Check all of the following before downstream use:
+
+1. expected input and output row counts;
+2. missing `nifti_path` or `mask_*` values;
+3. command-specific error and warning tables;
+4. whether filtering intentionally reduced radiomics rows.
+
+Checkpoint files and JSON state may appear beside the configured main/error
+outputs during resumable runs. They are implementation artifacts, not cohort
+tables, and should not be passed to the next stage.
+

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -1,0 +1,89 @@
+# Quickstart
+
+This example keeps raw DICOM data, tabular indexes, and generated NIfTI files
+in separate directories:
+
+```text
+project/
+├── dicom/          # source data; do not modify
+├── tables/         # CSV indexes and error reports
+└── nifti/          # converted images and masks
+```
+
+## 1. Inspect the plan
+
+Most pipeline commands support `--dry-run`. Use it to confirm resolved paths
+and settings before processing a cohort:
+
+```bash
+imperandi ingest \
+  --root_path ./project/dicom \
+  --output_dir ./project/tables \
+  --manifest generic \
+  --dry-run
+```
+
+## 2. Ingest DICOM metadata
+
+`ingest` runs `parse` and then `clean`:
+
+```bash
+imperandi ingest \
+  --root_path ./project/dicom \
+  --output_dir ./project/tables \
+  --manifest generic
+```
+
+The main result is `project/tables/dicom_index_clean.csv`, with one curated row
+per reconstructed volume. To inspect uncommon tags on a deterministic sample,
+add `--snapshot_tags`.
+
+## 3. Convert volumes to NIfTI
+
+```bash
+imperandi convert \
+  --csv_path ./project/tables/dicom_index_clean.csv \
+  --output_dir ./project/nifti \
+  --csv_path_out ./project/tables/nifti_index.csv
+```
+
+Successful rows gain a `nifti_path`. Conversion failures are written to
+`conv_errors.csv` without aborting all other rows.
+
+## 4. Segment images
+
+Install the `segment` extra first, then run the tasks from the selected
+manifest:
+
+```bash
+imperandi segment \
+  --csv_path ./project/tables/nifti_index.csv \
+  --csv_path_out ./project/tables/nifti_index_segmented.csv \
+  --manifest generic
+```
+
+Mask columns are named `mask_<output>`, such as `mask_liver` and
+`mask_liver_tumor`.
+
+## 5. Extract phase and radiomics
+
+```bash
+imperandi phase \
+  --csv_path ./project/tables/nifti_index_segmented.csv \
+  --csv_path_out ./project/tables/nifti_index_phased.csv
+
+imperandi radiomics \
+  --csv_path ./project/tables/nifti_index_phased.csv \
+  --csv_path_out ./project/tables/nifti_index_radiomics.csv \
+  --manifest generic
+```
+
+The phase command adds `totalseg_*` fields. Radiomics discovers all populated
+`mask_*` columns and appends feature columns to the table.
+
+## 6. Check failures before analysis
+
+Each heavy stage writes a command-specific error CSV. Review those reports and
+row counts rather than treating a zero process exit alone as proof that every
+volume succeeded. See [Outputs](outputs.md) for the complete file map.
+

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -1,0 +1,72 @@
+# Troubleshooting
+
+## The `segment` or `phase` command reports missing dependencies
+
+Install the TotalSegmentator feature set in the same environment that owns the
+`imperandi` executable:
+
+```bash
+python -m pip install -e ".[segment]"
+python -m imperandi segment --help
+```
+
+Using `python -m imperandi` is a quick way to detect when `pip` and the shell
+entry point refer to different environments.
+
+## Radiomics cannot import PyRadiomics
+
+Install `.[radiomics]`. The project currently sources PyRadiomics from its Git
+repository, so installation requires Git and network access. Confirm the input
+has `nifti_path` and at least one populated `mask_*` column.
+
+## No DICOM files are found
+
+- Check glob quoting so the shell does not expand it unexpectedly.
+- Try `--force_dicom_read` for non-conformant exports.
+- Raise `--archive_max_depth` only when archives are intentionally nested.
+- Add `--snapshot_tags` to inspect what is readable in a representative sample.
+- Use `--verbose` and reduce to a small root while diagnosing.
+
+## IDs are empty or unexpected
+
+Use `--id_source tags` to require tag-based identity or `--id_source path` for
+a stable directory hierarchy. Override the tag keywords with
+`--patient_key_from`, `--study_id_from`, and `--series_id_from`. When a manifest
+standardizes patient keys, compare `patient_key` with `_patient_key_raw`.
+
+## Cleaning removes too many volumes
+
+Inspect `Modality`, `ImageType`, `SeriesDescription`, orientation, spacing, and
+computed volume length in the parsed CSV. For legitimately short or long
+protocols, adjust the `--volume-length-min-mm` or
+`--volume-length-max-mm` bounds. Avoid broad threshold changes until you know
+which filter caused the loss.
+
+## Conversion fails for archive-backed series
+
+Ensure the archive remains at the same location recorded during parse. Set
+`--archive_cache_dir` to a filesystem with enough free space and permissions.
+`--keep_archive_cache` is useful for inspection but can consume substantial
+storage. Review `conv_errors.csv` for the affected rows.
+
+## A resumed run uses stale results
+
+Resume only occurs for compatible state, but lightweight fingerprints cannot
+detect every in-place content change. Use `--strict_resume` when inputs may have
+changed without a path/metadata change, or `--no_resume` to deliberately start
+fresh. Do not combine outputs from manifests with different task definitions.
+
+## Multiprocessing hangs or exhausts memory
+
+Reduce `--num_workers` and, for segmentation, keep the default
+`--start_method spawn`. Increase `--timeout_sec` only after confirming a volume
+is making progress. Parallel GPU workers also multiply model and image memory
+requirements.
+
+## The documentation build fails during API imports
+
+Build from the repository root after installing the package and
+`docs/requirements.txt`. The Sphinx configuration mocks heavy optional modules,
+but base runtime dependencies must still be installed through `pip install -e
+.`. Re-run with `-W --keep-going` to see all warnings in one build.
+

--- a/docs/source/workflow.md
+++ b/docs/source/workflow.md
@@ -1,0 +1,96 @@
+# Workflow
+
+IMPERANDI passes a cohort table from one stage to the next. Image data remains
+on disk; CSV path columns preserve the link between each source volume and its
+derived artifacts.
+
+```text
+DICOM roots / archives
+        │
+        ▼
+ parse ─────► dicom_index.csv
+        │
+        ▼
+ clean ─────► dicom_index_clean.csv
+        │
+        ▼
+ convert ───► nifti_index.csv + NIfTI images
+        │
+        ├────────► phase ─────► totalseg_* metadata
+        │
+        ▼
+ segment ───► mask_* paths
+        │
+        ▼
+ radiomics ─► feature columns
+```
+
+## Parse
+
+`parse` discovers files below one or more roots, reads the default selected
+DICOM tags plus any supplied with `--tags`, and resolves `patient_key`,
+`study_id`, and `series_id`.
+
+ID source modes are:
+
+- `auto` (default): prefer configured DICOM tags and fall back to path parts.
+- `tags`: derive IDs from DICOM tags.
+- `path`: derive IDs from the expected patient/study/series directory layout.
+
+ZIP, TAR, TAR.GZ, and TGZ inputs can be read without manually unpacking the
+whole dataset. Archive recursion is bounded by `--archive_max_depth`; temporary
+materialization is removed unless `--keep_archive_cache` is set.
+
+## Clean
+
+`clean` groups instances into volumes, standardizes dates and times, orders
+exams/acquisitions, and rejects unsuitable data. The implemented filters cover
+non-CT data, localizers and secondary images, non-axial geometry, noise/body
+region patterns, implausible volume length, pixel spacing, and slice thickness.
+Missing geometry is generally retained for later review rather than silently
+treated as a failure.
+
+The default accepted reconstructed length is 30–1700 mm. Override it with
+`--volume-length-min-mm` and `--volume-length-max-mm` when a protocol calls for
+different bounds.
+
+## Convert
+
+`convert` materializes each curated series and delegates DICOM-to-NIfTI
+conversion to `dicom2nifti`. It works in parallel and records per-volume
+failures separately. Its input needs a `dicom_path` representation produced by
+ingest; output rows receive `nifti_path`.
+
+## Segment, phase, and radiomics
+
+`segment` runs manifest-defined TotalSegmentator tasks and optional mask
+post-processing. `phase` runs TotalSegmentator's CT contrast-phase extractor.
+`radiomics` computes PyRadiomics features for every `mask_*` column, including
+an organ-minus-tumor strategy when paired organ and tumor masks are present.
+
+Phase can run immediately after conversion. Segmentation must precede
+radiomics because radiomics requires one or more mask columns.
+
+## Checkpoints and resume
+
+`parse`, `convert`, `segment`, `phase`, and `radiomics` checkpoint long runs.
+Resume is enabled by default when the saved command state and input fingerprint
+match. Common controls are:
+
+- `--checkpoint_every_rows N`: flush after N processed rows.
+- `--checkpoint_every_sec T`: flush after T seconds.
+- `--no_resume`: ignore matching checkpoint state and start a fresh run.
+- `--strict_resume`: hash input contents instead of relying on the lightweight
+  fingerprint; this is safer but slower on large inputs.
+
+Changing material arguments or inputs invalidates an incompatible checkpoint.
+Do not manually edit checkpoint/state files while a command is running.
+
+## Operational recommendations
+
+- Keep raw DICOM roots read-only.
+- Store each stage's CSV under versioned or run-specific paths.
+- Start with a small cohort and `--num_workers 1` when validating a manifest.
+- Preserve error CSVs and logs with the corresponding output table.
+- Use explicit output paths in automation instead of relying on defaults.
+


### PR DESCRIPTION
Adds structured Sphinx documentation for IMPERANDI, covering installation, core workflows, CLI usage, outputs, manifests, troubleshooting, and the Python API.